### PR TITLE
Change the <operation.HttpMethod> to <operation.HttpMethodUpper>

### DIFF
--- a/src/NSwag.CodeGeneration/CodeGenerators/TypeScript/Templates/AngularJS.txt
+++ b/src/NSwag.CodeGeneration/CodeGenerators/TypeScript/Templates/AngularJS.txt
@@ -66,7 +66,7 @@ export class <class> <if(generateClientInterfaces)>implements I<class> <endif>{
 
         return this.http({
             url: url,
-            method: "<operation.HttpMethod>",
+            method: "<operation.HttpMethodUpper>",
             data: content,
             headers: {
 <operation.HeaderParameters:{parameter | 


### PR DESCRIPTION
I'm using your project to generate my AngularJS api client, and I found a problem, the METHOD of the http call was empty, I notice that AngularJs.txt T4 was using "operation.HttpMethod" instead "operation.HttpMethodUpper" which is been using Jquery T4 template who works fine.