### PR TITLE
fixed conditional usging text instead number

### DIFF
--- a/src/NSwag.CodeGeneration/CodeGenerators/TypeScript/Templates/AngularJS.txt
+++ b/src/NSwag.CodeGeneration/CodeGenerators/TypeScript/Templates/AngularJS.txt
@@ -1,4 +1,4 @@
-﻿// The Angular client template is currently NOT TESTET!
+// The Angular client template is currently NOT TESTET!
 
 <if(hasOperations)>
 <if(generateClientInterfaces)>
@@ -83,7 +83,7 @@ export class <class> <if(generateClientInterfaces)>implements I<class> <endif>{
         var status = response.status; 
 
 <operation.Responses:{response | 
-        if (status === "<response.StatusCode>") {
+        if (status === <response.StatusCode>) {
 <if(response.HasType)>
             var result<response.StatusCode>: <response.Type> = null; 
     <if(response.TypeIsDate)>


### PR DESCRIPTION
The property "status" in the response object is a number, I fixed the conditional

[Angular http documentation](https://docs.angularjs.org/api/ng/service/$http)