### PR TITLE
can now resolve dll dependencies outside of webapi assembly folder

### DIFF
--- a/src/NSwag.CodeGeneration/SwaggerGenerators/WebApi/WebApiAssemblyToSwaggerGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration/SwaggerGenerators/WebApi/WebApiAssemblyToSwaggerGeneratorSettings.cs
@@ -13,5 +13,8 @@ namespace NSwag.CodeGeneration.SwaggerGenerators.WebApi
     {
         /// <summary>Gets or sets the Web API assembly path.</summary>
         public string AssemblyPath { get; set; }
+
+        /// <summary>Gets ot sets the paths where to search for referenced assemblies</summary>
+        public string[] ReferencePaths { get; set; }
     }
 }

--- a/src/NSwag/Commands/WebApiToSwaggerCommand.cs
+++ b/src/NSwag/Commands/WebApiToSwaggerCommand.cs
@@ -29,6 +29,14 @@ namespace NSwag.Commands
             get { return Settings.AssemblyPath; }
             set { Settings.AssemblyPath = value; }
         }
+        
+        [Description("The path to seach for referenced assemblies files.")]
+        [Argument(Name = "ReferencePaths", DefaultValue = "")]
+        public string[] ReferencePaths
+        {
+            get { return Settings.ReferencePaths; }
+            set { Settings.ReferencePaths = value; }
+        }
 
         [Description("The Web API controller full class name or empty to load all controllers from the assembly.")]
         [Argument(Name = "Controller", DefaultValue = null)]


### PR DESCRIPTION
Added a ReferencePaths parameter to the WebApiAssemblyToSwagger command to provide additional folders where to look for referenced assemblies