### PR TITLE
Create empty response when using ResponseType attribute with void

### DIFF
--- a/src/NSwag.CodeGeneration/SwaggerGenerators/WebApi/WebApiToSwaggerGenerator.cs
+++ b/src/NSwag.CodeGeneration/SwaggerGenerators/WebApi/WebApiToSwaggerGenerator.cs
@@ -646,12 +646,14 @@ namespace NSwag.CodeGeneration.SwaggerGenerators.WebApi
                             description = dynResultTypeAttribute.Description;
                     }
 
-                    operation.Responses[httpStatusCode] = new SwaggerResponse
-                    {
-                        Description = description ?? string.Empty,
-                        IsNullableRaw = mayBeNull,
-                        Schema = CreateAndAddSchema(service, returnType, mayBeNull, null, schemaResolver)
-                    };
+                    operation.Responses[httpStatusCode] = IsVoidResponse(returnType) ?
+                        new SwaggerResponse() :
+                        new SwaggerResponse
+                        {
+                            Description = description ?? string.Empty,
+                            IsNullableRaw = mayBeNull,
+                            Schema = CreateAndAddSchema(service, returnType, mayBeNull, null, schemaResolver)
+                        };
                 }
             }
             else


### PR DESCRIPTION
 - used same behavior as for default result types
 - on code generation permits to create resultType as Task instead of Task<void>