### PR TITLE
Make model public

### DIFF
--- a/src/NSwag.CodeGeneration/CodeGenerators/CSharp/Models/ClientTemplateModel.cs
+++ b/src/NSwag.CodeGeneration/CodeGenerators/CSharp/Models/ClientTemplateModel.cs
@@ -12,11 +12,21 @@ using NSwag.CodeGeneration.CodeGenerators.Models;
 
 namespace NSwag.CodeGeneration.CodeGenerators.CSharp.Models
 {
-    internal class ClientTemplateModel
+    /// <summary>
+    /// 
+    /// </summary>
+    public class ClientTemplateModel
     {
         private readonly SwaggerService _service;
         private readonly SwaggerToCSharpClientGeneratorSettings _settings;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClientTemplateModel"/> class.
+        /// </summary>
+        /// <param name="controllerName">Name of the controller.</param>
+        /// <param name="operations">The operations.</param>
+        /// <param name="service">The service.</param>
+        /// <param name="settings">The settings.</param>
         public ClientTemplateModel(string controllerName, IList<OperationModel> operations, SwaggerService service, SwaggerToCSharpClientGeneratorSettings settings)
         {
             _service = service;
@@ -26,30 +36,108 @@ namespace NSwag.CodeGeneration.CodeGenerators.CSharp.Models
             Operations = operations;
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether [generate contracts].
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [generate contracts]; otherwise, <c>false</c>.
+        /// </value>
         public bool GenerateContracts { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether [generate implementation].
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if [generate implementation]; otherwise, <c>false</c>.
+        /// </value>
         public bool GenerateImplementation { get; set; }
 
+        /// <summary>
+        /// Gets the class.
+        /// </summary>
+        /// <value>
+        /// The class.
+        /// </value>
         public string Class { get; }
 
+        /// <summary>
+        /// Gets the base class.
+        /// </summary>
+        /// <value>
+        /// The base class.
+        /// </value>
         public string BaseClass => _settings.ClientBaseClass;
 
+        /// <summary>
+        /// Gets a value indicating whether this instance has base class.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance has base class; otherwise, <c>false</c>.
+        /// </value>
         public bool HasBaseClass => !string.IsNullOrEmpty(_settings.ClientBaseClass);
 
+        /// <summary>
+        /// Gets the configuration class.
+        /// </summary>
+        /// <value>
+        /// The configuration class.
+        /// </value>
         public string ConfigurationClass => _settings.ConfigurationClass;
 
+        /// <summary>
+        /// Gets a value indicating whether this instance has configuration class.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance has configuration class; otherwise, <c>false</c>.
+        /// </value>
         public bool HasConfigurationClass => !string.IsNullOrEmpty(_settings.ConfigurationClass);
 
+        /// <summary>
+        /// Gets a value indicating whether this instance has base type.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance has base type; otherwise, <c>false</c>.
+        /// </value>
         public bool HasBaseType => _settings.GenerateClientInterfaces || HasBaseClass;
 
+        /// <summary>
+        /// Gets a value indicating whether [use HTTP client creation method].
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if [use HTTP client creation method]; otherwise, <c>false</c>.
+        /// </value>
         public bool UseHttpClientCreationMethod => _settings.UseHttpClientCreationMethod;
 
+        /// <summary>
+        /// Gets a value indicating whether [generate client interfaces].
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if [generate client interfaces]; otherwise, <c>false</c>.
+        /// </value>
         public bool GenerateClientInterfaces => _settings.GenerateClientInterfaces;
 
+        /// <summary>
+        /// Gets the base URL.
+        /// </summary>
+        /// <value>
+        /// The base URL.
+        /// </value>
         public string BaseUrl => _service.BaseUrl;
 
+        /// <summary>
+        /// Gets the operations.
+        /// </summary>
+        /// <value>
+        /// The operations.
+        /// </value>
         public IList<OperationModel> Operations { get; }
 
+        /// <summary>
+        /// Gets a value indicating whether this instance has operations.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance has operations; otherwise, <c>false</c>.
+        /// </value>
         public bool HasOperations => Operations.Any();
     }
 }

--- a/src/NSwag.CodeGeneration/CodeGenerators/Models/OperationModel.cs
+++ b/src/NSwag.CodeGeneration/CodeGenerators/Models/OperationModel.cs
@@ -12,68 +12,257 @@ using NJsonSchema.CodeGeneration;
 
 namespace NSwag.CodeGeneration.CodeGenerators.Models
 {
-    internal class OperationModel
+    /// <summary>
+    /// 
+    /// </summary>
+    public class OperationModel
     {
+        /// <summary>
+        /// Gets the identifier.
+        /// </summary>
+        /// <value>
+        /// The identifier.
+        /// </value>
         public string Id => Operation.OperationId;
 
+        /// <summary>
+        /// Gets or sets the path.
+        /// </summary>
+        /// <value>
+        /// The path.
+        /// </value>
         public string Path { get; set; }
 
+        /// <summary>
+        /// Gets or sets the operation.
+        /// </summary>
+        /// <value>
+        /// The operation.
+        /// </value>
         public SwaggerOperation Operation { get; set; }
 
+        /// <summary>
+        /// Gets or sets the HTTP method.
+        /// </summary>
+        /// <value>
+        /// The HTTP method.
+        /// </value>
         public SwaggerOperationMethod HttpMethod { get; set; }
 
+        /// <summary>
+        /// Gets or sets the name of the operation.
+        /// </summary>
+        /// <value>
+        /// The name of the operation.
+        /// </value>
         public string OperationName { get; set; }
 
+        /// <summary>
+        /// Gets the HTTP method upper.
+        /// </summary>
+        /// <value>
+        /// The HTTP method upper.
+        /// </value>
         public string HttpMethodUpper => ConversionUtilities.ConvertToUpperCamelCase(HttpMethod.ToString(), false);
 
+        /// <summary>
+        /// Gets the HTTP method lower.
+        /// </summary>
+        /// <value>
+        /// The HTTP method lower.
+        /// </value>
         public string HttpMethodLower => ConversionUtilities.ConvertToLowerCamelCase(HttpMethod.ToString(), false);
 
+        /// <summary>
+        /// Gets a value indicating whether this instance is get or delete.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is get or delete; otherwise, <c>false</c>.
+        /// </value>
         public bool IsGetOrDelete => HttpMethod == SwaggerOperationMethod.Get || HttpMethod == SwaggerOperationMethod.Delete;
 
+        /// <summary>
+        /// Gets the operation name lower.
+        /// </summary>
+        /// <value>
+        /// The operation name lower.
+        /// </value>
         public string OperationNameLower => ConversionUtilities.ConvertToLowerCamelCase(OperationName, false);
 
+        /// <summary>
+        /// Gets the operation name upper.
+        /// </summary>
+        /// <value>
+        /// The operation name upper.
+        /// </value>
         public string OperationNameUpper => ConversionUtilities.ConvertToUpperCamelCase(OperationName, false);
 
+        /// <summary>
+        /// Gets or sets the type of the result.
+        /// </summary>
+        /// <value>
+        /// The type of the result.
+        /// </value>
         public string ResultType { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance has result type.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance has result type; otherwise, <c>false</c>.
+        /// </value>
         public bool HasResultType { get; set; }
 
+        /// <summary>
+        /// Gets or sets the result description.
+        /// </summary>
+        /// <value>
+        /// The result description.
+        /// </value>
         public string ResultDescription { get; set; }
 
+        /// <summary>
+        /// Gets a value indicating whether this instance has result description.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance has result description; otherwise, <c>false</c>.
+        /// </value>
         public bool HasResultDescription => !string.IsNullOrEmpty(ResultDescription);
 
+        /// <summary>
+        /// Gets or sets the type of the exception.
+        /// </summary>
+        /// <value>
+        /// The type of the exception.
+        /// </value>
         public string ExceptionType { get; set; }
 
+        /// <summary>
+        /// Gets or sets the responses.
+        /// </summary>
+        /// <value>
+        /// The responses.
+        /// </value>
         public List<ResponseModel> Responses { get; set; }
 
+        /// <summary>
+        /// Gets or sets the default response.
+        /// </summary>
+        /// <value>
+        /// The default response.
+        /// </value>
         public ResponseModel DefaultResponse { get; set; }
 
+        /// <summary>
+        /// Gets or sets the parameters.
+        /// </summary>
+        /// <value>
+        /// The parameters.
+        /// </value>
         public IEnumerable<ParameterModel> Parameters { get; set; }
-        
+
+        /// <summary>
+        /// Gets a value indicating whether this instance has default response.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance has default response; otherwise, <c>false</c>.
+        /// </value>
         public bool HasDefaultResponse => DefaultResponse != null;
 
+        /// <summary>
+        /// Gets a value indicating whether this instance has only default response.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance has only default response; otherwise, <c>false</c>.
+        /// </value>
         public bool HasOnlyDefaultResponse => Responses.Count == 0 && HasDefaultResponse;
-        
+
+        /// <summary>
+        /// Gets a value indicating whether this instance has content.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance has content; otherwise, <c>false</c>.
+        /// </value>
         public bool HasContent => ContentParameter != null;
 
+        /// <summary>
+        /// Gets the content parameter.
+        /// </summary>
+        /// <value>
+        /// The content parameter.
+        /// </value>
         public ParameterModel ContentParameter => Parameters.SingleOrDefault(p => p.Kind == SwaggerParameterKind.Body);
 
+        /// <summary>
+        /// Gets the path parameters.
+        /// </summary>
+        /// <value>
+        /// The path parameters.
+        /// </value>
         public IEnumerable<ParameterModel> PathParameters => Parameters.Where(p => p.Kind == SwaggerParameterKind.Path);
 
+        /// <summary>
+        /// Gets the query parameters.
+        /// </summary>
+        /// <value>
+        /// The query parameters.
+        /// </value>
         public IEnumerable<ParameterModel> QueryParameters => Parameters.Where(p => p.Kind == SwaggerParameterKind.Query);
 
+        /// <summary>
+        /// Gets the header parameters.
+        /// </summary>
+        /// <value>
+        /// The header parameters.
+        /// </value>
         public IEnumerable<ParameterModel> HeaderParameters => Parameters.Where(p => p.Kind == SwaggerParameterKind.Header);
 
+        /// <summary>
+        /// Gets the form parameters.
+        /// </summary>
+        /// <value>
+        /// The form parameters.
+        /// </value>
         public IEnumerable<ParameterModel> FormParameters => Parameters.Where(p => p.Kind == SwaggerParameterKind.FormData);
 
+        /// <summary>
+        /// Gets the summary.
+        /// </summary>
+        /// <value>
+        /// The summary.
+        /// </value>
         public string Summary => ConversionUtilities.TrimWhiteSpaces(Operation.Summary);
 
+        /// <summary>
+        /// Gets a value indicating whether this instance has summary.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance has summary; otherwise, <c>false</c>.
+        /// </value>
         public bool HasSummary => !string.IsNullOrEmpty(Summary);
 
+        /// <summary>
+        /// Gets a value indicating whether this instance has documentation.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance has documentation; otherwise, <c>false</c>.
+        /// </value>
         public bool HasDocumentation => HasSummary || HasResultDescription || Parameters.Any(p => p.HasDescription) || Operation.IsDeprecated;
 
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance has form parameters.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance has form parameters; otherwise, <c>false</c>.
+        /// </value>
         public bool HasFormParameters { get; set; }
 
+        /// <summary>
+        /// Gets a value indicating whether this instance is deprecated.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is deprecated; otherwise, <c>false</c>.
+        /// </value>
         public bool IsDeprecated => Operation.IsDeprecated;
     }
 }

--- a/src/NSwag.CodeGeneration/CodeGenerators/Models/ParameterModel.cs
+++ b/src/NSwag.CodeGeneration/CodeGenerators/Models/ParameterModel.cs
@@ -12,12 +12,22 @@ using NJsonSchema.CodeGeneration;
 
 namespace NSwag.CodeGeneration.CodeGenerators.Models
 {
-    internal class ParameterModel
+    /// <summary>
+    /// 
+    /// </summary>
+    public class ParameterModel
     {
         private readonly SwaggerOperation _operation;
         private readonly SwaggerParameter _parameter;
         private readonly CodeGeneratorSettingsBase _settings;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ParameterModel"/> class.
+        /// </summary>
+        /// <param name="typeName">Name of the type.</param>
+        /// <param name="operation">The operation.</param>
+        /// <param name="parameter">The parameter.</param>
+        /// <param name="settings">The settings.</param>
         public ParameterModel(string typeName, SwaggerOperation operation, SwaggerParameter parameter, CodeGeneratorSettingsBase settings)
         {
             Type = typeName;
@@ -26,42 +36,150 @@ namespace NSwag.CodeGeneration.CodeGenerators.Models
             _settings = settings;
         }
 
+        /// <summary>
+        /// Gets the type.
+        /// </summary>
+        /// <value>
+        /// The type.
+        /// </value>
         public string Type { get; }
 
+        /// <summary>
+        /// Gets the name.
+        /// </summary>
+        /// <value>
+        /// The name.
+        /// </value>
         public string Name => _parameter.Name;
 
+        /// <summary>
+        /// Gets the variable name lower.
+        /// </summary>
+        /// <value>
+        /// The variable name lower.
+        /// </value>
         public string VariableNameLower => ConversionUtilities.ConvertToLowerCamelCase(_parameter.Name.Replace("-", "_").Replace(".", "_"), true);
 
+        /// <summary>
+        /// Gets the kind.
+        /// </summary>
+        /// <value>
+        /// The kind.
+        /// </value>
         public SwaggerParameterKind Kind => _parameter.Kind;
 
+        /// <summary>
+        /// Gets the description.
+        /// </summary>
+        /// <value>
+        /// The description.
+        /// </value>
         public string Description => ConversionUtilities.TrimWhiteSpaces(_parameter.Description);
 
+        /// <summary>
+        /// Gets the schema.
+        /// </summary>
+        /// <value>
+        /// The schema.
+        /// </value>
         public JsonSchema4 Schema => _parameter.ActualSchema;
 
+        /// <summary>
+        /// Gets a value indicating whether this instance is required.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is required; otherwise, <c>false</c>.
+        /// </value>
         public bool IsRequired => _parameter.IsRequired;
 
+        /// <summary>
+        /// Gets a value indicating whether this instance is nullable.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is nullable; otherwise, <c>false</c>.
+        /// </value>
         public bool IsNullable => _parameter.IsNullable(_settings.NullHandling);
 
-        public bool IsOptional => _parameter.IsRequired == false; 
+        /// <summary>
+        /// Gets a value indicating whether this instance is optional.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is optional; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsOptional => _parameter.IsRequired == false;
 
+        /// <summary>
+        /// Gets a value indicating whether this instance has description.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance has description; otherwise, <c>false</c>.
+        /// </value>
         public bool HasDescription => !string.IsNullOrEmpty(Description);
 
+        /// <summary>
+        /// Gets a value indicating whether this instance has description or is optional.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance has description or is optional; otherwise, <c>false</c>.
+        /// </value>
         public bool HasDescriptionOrIsOptional => HasDescription || !IsRequired;
 
+        /// <summary>
+        /// Gets a value indicating whether this instance is last.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance is last; otherwise, <c>false</c>.
+        /// </value>
         public bool IsLast => _operation.ActualParameters.LastOrDefault() == _parameter;
 
+        /// <summary>
+        /// Gets a value indicating whether this instance is date.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance is date; otherwise, <c>false</c>.
+        /// </value>
         public bool IsDate => Schema.Type == JsonObjectType.String && Schema.Format == JsonFormatStrings.DateTime;
 
+        /// <summary>
+        /// Gets a value indicating whether this instance is array.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance is array; otherwise, <c>false</c>.
+        /// </value>
         public bool IsArray => Schema.Type.HasFlag(JsonObjectType.Array);
 
+        /// <summary>
+        /// Gets a value indicating whether this instance is file.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance is file; otherwise, <c>false</c>.
+        /// </value>
         public bool IsFile => Schema.Type.HasFlag(JsonObjectType.File);
 
+        /// <summary>
+        /// Gets a value indicating whether this instance is dictionary.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is dictionary; otherwise, <c>false</c>.
+        /// </value>
         public bool IsDictionary => Schema.IsDictionary;
 
+        /// <summary>
+        /// Gets a value indicating whether this instance is date array.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is date array; otherwise, <c>false</c>.
+        /// </value>
         public bool IsDateArray => IsArray && Schema.Item?.Format == JsonFormatStrings.DateTime;
 
         // TODO: Find way to remove TypeScript only properties
 
+        /// <summary>
+        /// Gets or sets a value indicating whether [use dto class].
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [use dto class]; otherwise, <c>false</c>.
+        /// </value>
         public bool UseDtoClass { get; set; } = false;
     }
 }

--- a/src/NSwag.CodeGeneration/CodeGenerators/Models/ResponseModel.cs
+++ b/src/NSwag.CodeGeneration/CodeGenerators/Models/ResponseModel.cs
@@ -12,11 +12,19 @@ using NJsonSchema;
 
 namespace NSwag.CodeGeneration.CodeGenerators.Models
 {
-    internal class ResponseModel
+    /// <summary>
+    /// 
+    /// </summary>
+    public class ResponseModel
     {
         private readonly SwaggerResponse _response;
         private readonly ClientGeneratorBase _clientGeneratorBase;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ResponseModel"/> class.
+        /// </summary>
+        /// <param name="response">The response.</param>
+        /// <param name="clientGeneratorBase">The client generator base.</param>
         public ResponseModel(KeyValuePair<string, SwaggerResponse> response, ClientGeneratorBase clientGeneratorBase)
         {
             _response = response.Value;
@@ -25,24 +33,84 @@ namespace NSwag.CodeGeneration.CodeGenerators.Models
             StatusCode = response.Key;
         }
 
+        /// <summary>
+        /// Gets the status code.
+        /// </summary>
+        /// <value>
+        /// The status code.
+        /// </value>
         public string StatusCode { get; }
 
+        /// <summary>
+        /// Gets the type.
+        /// </summary>
+        /// <value>
+        /// The type.
+        /// </value>
         public string Type => _clientGeneratorBase.GetType(_response.ActualResponseSchema, IsNullable, "Response");
 
+        /// <summary>
+        /// Gets a value indicating whether this instance has type.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance has type; otherwise, <c>false</c>.
+        /// </value>
         public bool HasType => Schema != null;
 
+        /// <summary>
+        /// Gets a value indicating whether this instance is success.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is success; otherwise, <c>false</c>.
+        /// </value>
         public bool IsSuccess => HttpUtilities.IsSuccessStatusCode(StatusCode);
 
+        /// <summary>
+        /// Gets a value indicating whether this instance is date.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance is date; otherwise, <c>false</c>.
+        /// </value>
         public bool IsDate => _clientGeneratorBase.GetType(_response.ActualResponseSchema, IsNullable, "Response") == "Date";
 
+        /// <summary>
+        /// Gets a value indicating whether this instance is file.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance is file; otherwise, <c>false</c>.
+        /// </value>
         public bool IsFile => Schema != null && Schema.ActualSchema.Type == JsonObjectType.File;
 
+        /// <summary>
+        /// Gets the actual response schema.
+        /// </summary>
+        /// <value>
+        /// The actual response schema.
+        /// </value>
         public JsonSchema4 ActualResponseSchema => _response.ActualResponseSchema;
 
+        /// <summary>
+        /// Gets the schema.
+        /// </summary>
+        /// <value>
+        /// The schema.
+        /// </value>
         private JsonSchema4 Schema => _response.Schema?.ActualSchema;
 
+        /// <summary>
+        /// Gets a value indicating whether this instance is nullable.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is nullable; otherwise, <c>false</c>.
+        /// </value>
         public bool IsNullable => _response.IsNullable(_clientGeneratorBase.BaseSettings.CodeGeneratorSettings.NullHandling);
 
+        /// <summary>
+        /// Gets a value indicating whether [type inherits from exception].
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if [type inherits from exception]; otherwise, <c>false</c>.
+        /// </value>
         public bool TypeInheritsFromException => _response
             .ActualResponseSchema?
             .InheritedSchemas
@@ -50,8 +118,20 @@ namespace NSwag.CodeGeneration.CodeGenerators.Models
 
         // TODO: Find way to remove TypeScript only properties
 
+        /// <summary>
+        /// Gets or sets the data conversion code.
+        /// </summary>
+        /// <value>
+        /// The data conversion code.
+        /// </value>
         public string DataConversionCode { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether [use dto class].
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [use dto class]; otherwise, <c>false</c>.
+        /// </value>
         public bool UseDtoClass { get; set; }
     }
 }

--- a/src/NSwag.CodeGeneration/CodeGenerators/TypeScript/Models/ClientTemplateModel.cs
+++ b/src/NSwag.CodeGeneration/CodeGenerators/TypeScript/Models/ClientTemplateModel.cs
@@ -13,8 +13,18 @@ using NSwag.CodeGeneration.CodeGenerators.Models;
 
 namespace NSwag.CodeGeneration.CodeGenerators.TypeScript.Models
 {
-    internal class ClientTemplateModel
+    /// <summary>
+    /// 
+    /// </summary>
+    public class ClientTemplateModel
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClientTemplateModel"/> class.
+        /// </summary>
+        /// <param name="controllerName">Name of the controller.</param>
+        /// <param name="operations">The operations.</param>
+        /// <param name="service">The service.</param>
+        /// <param name="settings">The settings.</param>
         public ClientTemplateModel(string controllerName, IList<OperationModel> operations, SwaggerService service, SwaggerToTypeScriptClientGeneratorSettings settings)
         {
             Class = controllerName;
@@ -31,22 +41,76 @@ namespace NSwag.CodeGeneration.CodeGenerators.TypeScript.Models
             PromiseConstructor = settings.PromiseType == TypeScript.PromiseType.Promise ? "new Promise" : "Q.Promise";
         }
 
+        /// <summary>
+        /// Gets the class.
+        /// </summary>
+        /// <value>
+        /// The class.
+        /// </value>
         public string Class { get; }
 
+        /// <summary>
+        /// Gets a value indicating whether this instance is extended.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is extended; otherwise, <c>false</c>.
+        /// </value>
         public bool IsExtended { get; }
 
+        /// <summary>
+        /// Gets a value indicating whether this instance has operations.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance has operations; otherwise, <c>false</c>.
+        /// </value>
         public bool HasOperations { get; }
 
+        /// <summary>
+        /// Gets the operations.
+        /// </summary>
+        /// <value>
+        /// The operations.
+        /// </value>
         public IList<OperationModel> Operations { get; }
 
+        /// <summary>
+        /// Gets a value indicating whether [uses knockout].
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [uses knockout]; otherwise, <c>false</c>.
+        /// </value>
         public bool UsesKnockout { get; }
 
+        /// <summary>
+        /// Gets the base URL.
+        /// </summary>
+        /// <value>
+        /// The base URL.
+        /// </value>
         public string BaseUrl { get; }
 
+        /// <summary>
+        /// Gets a value indicating whether [generate client interfaces].
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if [generate client interfaces]; otherwise, <c>false</c>.
+        /// </value>
         public bool GenerateClientInterfaces { get; }
 
+        /// <summary>
+        /// Gets the type of the promise.
+        /// </summary>
+        /// <value>
+        /// The type of the promise.
+        /// </value>
         public string PromiseType { get; }
 
+        /// <summary>
+        /// Gets the promise constructor.
+        /// </summary>
+        /// <value>
+        /// The promise constructor.
+        /// </value>
         public string PromiseConstructor { get; }
     }
 }


### PR DESCRIPTION
Hi. From 5.x version I am able to use ITemplateFactory to provide my own templates. That's really good approach (I made something similar in my previous fork) but there is just one problem - models are still internal so I can't easily access theirs properties. Also I don't have intelisense on my T4 template. There will be much easier if I can use them directly in my code. I have create PR with appropriate changes. Please take a look and tell me: if this is good approach and if not how I can easily reuse your model?