### PR TITLE
Adding Extension Data to SwaggerOperation to represent Swagger Extens…

### DIFF
--- a/src/NSwag.Core/SwaggerOperation.cs
+++ b/src/NSwag.Core/SwaggerOperation.cs
@@ -92,6 +92,10 @@ namespace NSwag
         [JsonProperty(PropertyName = "security", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public List<SwaggerSecurityRequirement> Security { get; set; }
 
+        /// <summary>Get or set the schema less extensions (this can be used as vendor extensions as well).</summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> ExtensionData { get; set; }
+
         /// <summary>Gets the list of MIME types the operation can consume, either from the operation or from the <see cref="SwaggerService"/>.</summary>
         [JsonIgnore]
         public IEnumerable<string> ActualConsumes => Consumes ?? Parent.Parent.Consumes;


### PR DESCRIPTION
ExtensionData Field which represents Vendor Extensions is only present in SwaggerResponse.cs.
Adding it to SwaggerOperation.cs as Operation Object in Swagger2.0 spec also supports Vendor Extensions [http://swagger.io/specification/#operationObject]