### PR TITLE
Removed unnecessary Owin dependency

### DIFF
--- a/src/NSwag.AssemblyLoader/NSwag.AssemblyLoader.csproj
+++ b/src/NSwag.AssemblyLoader/NSwag.AssemblyLoader.csproj
@@ -35,10 +35,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
@@ -49,10 +45,6 @@
     </Reference>
     <Reference Include="NJsonSchema.CodeGeneration, Version=4.26.6123.28533, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
       <HintPath>..\packages\NJsonSchema.CodeGeneration.4.26.6123.28533\lib\portable45-net45+win8+wp8+wpa81\NJsonSchema.CodeGeneration.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
-      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/NSwag.AssemblyLoader/packages.config
+++ b/src/NSwag.AssemblyLoader/packages.config
@@ -1,9 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.NETCore.Portable.Compatibility" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NJsonSchema" version="4.26.6123.28532" targetFramework="net45" />
   <package id="NJsonSchema.CodeGeneration" version="4.26.6123.28533" targetFramework="net45" />
-  <package id="Owin" version="1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
NSwag.AssemblyLoader has a dependency on Microsoft.Owin and Owin, which causes the NuGet package to depend on these as well.

This PR simply removes those two. Everything compiles so it seems they are not needed.