### PR TITLE
bug in AngularJS client generation

### DIFF
--- a/src/NSwag.CodeGeneration/CodeGenerators/TypeScript/Templates/AngularJSClientTemplate.cs
+++ b/src/NSwag.CodeGeneration/CodeGenerators/TypeScript/Templates/AngularJSClientTemplate.cs
@@ -461,7 +461,7 @@ if(!parameter.IsLast){
             #line hidden
             
             #line 52 "C:\Data\Projects\NSwag\src\NSwag.CodeGeneration\CodeGenerators\TypeScript\Templates\AngularJSClientTemplate.tt"
-if(operation.PathParameters.Any()){
+if(operation.QueryParameters.Any()){
             
             #line default
             #line hidden

--- a/src/NSwag.CodeGeneration/CodeGenerators/TypeScript/Templates/AngularJSClientTemplate.tt
+++ b/src/NSwag.CodeGeneration/CodeGenerators/TypeScript/Templates/AngularJSClientTemplate.tt
@@ -49,7 +49,7 @@ export class <#=Model.Class#> <#if(Model.GenerateClientInterfaces){#>implements 
 <#}#><#if(operation.IsDeprecated){#>     * @deprecated
 <#}#>     */
 <#}#>    <#=operation.OperationNameLower#>(<#foreach(var parameter in operation.Parameters){#><#=parameter.VariableNameLower#>: <#=parameter.Type#><#if(!parameter.IsLast){#>, <#}#><#}#>): ng.IPromise<<#=operation.ResultType#>> {
-        let url_ = this.baseUrl + "/<#=operation.Path#><#if(operation.PathParameters.Any()){#>?<#}#>"; 
+        let url_ = this.baseUrl + "/<#=operation.Path#><#if(operation.QueryParameters.Any()){#>?<#}#>"; 
 
 <#foreach(var parameter in operation.PathParameters){#>
         if (<#=parameter.VariableNameLower#> === undefined || <#=parameter.VariableNameLower#> === null)


### PR DESCRIPTION
in AngularJS client code generation "?" is not added to url when there are any query parameters and no path parameters.

for web api controller below
```
    [RoutePrefix("api/v1")]
    [Authorize]
    public class ValuesController : ApiController
    {
        [HttpGet]
        [Route("foo")]
        [ResponseType("200", typeof(IEnumerable<int>))]
        public IHttpActionResult Get(string date, int tagId, int dataTypeId)
        {
            return Ok(new[] { 1, 2, 3 });
        }
    }
```
generated AngularJS client code is as below, missing "?" at the end
```
    get(date: string, tagId: number, dataTypeId: number): ng.IPromise<number[]> {
        let url_ = this.baseUrl + "/api/v1/foo"; 

        if (date === undefined)
            throw new Error("The parameter 'date' must be defined.");
        else
            url_ += "date=" + encodeURIComponent("" + date) + "&"; 
        if (tagId === undefined || tagId === null)
            throw new Error("The parameter 'tagId' must be defined and cannot be null.");
        else
            url_ += "tagId=" + encodeURIComponent("" + tagId) + "&"; 
        if (dataTypeId === undefined || dataTypeId === null)
            throw new Error("The parameter 'dataTypeId' must be defined and cannot be null.");
        else
            url_ += "dataTypeId=" + encodeURIComponent("" + dataTypeId) + "&"; 

        const content_ = "";

        return this.http({
            url: url_,
            method: "GET",
            data: content_,
            transformResponse: [], 
            headers: {
                "Content-Type": "application/json; charset=UTF-8"
            }
        }).then((response) => {
            return this.processGet(response);
        });
    }
```