### PR TITLE
Fix argument name to match property name

### DIFF
--- a/src/NSwag/Commands/SwaggerToCSharpClientCommand.cs
+++ b/src/NSwag/Commands/SwaggerToCSharpClientCommand.cs
@@ -72,7 +72,7 @@ namespace NSwag.Commands
         }
         
         [Description("Specifies the custom Json.NET converter types (optional, comma separated).")]
-        [Argument(Name = "UseHttpClientCreationMethod", IsRequired = false)]
+        [Argument(Name = "JsonConverters", IsRequired = false)]
         public string[] JsonConverters
         {
             get { return Settings.CSharpGeneratorSettings.JsonConverters; }


### PR DESCRIPTION
Looks like this was a missed change from a copy/paste.

Added in: https://github.com/NSwag/NSwag/commit/c7ecee95422b17f9a50681df93339fbe01c5665e
