### PR TITLE
Add NullHandling parameter to AssemblyTypeToSwaggerCommandBase

### DIFF
--- a/src/NSwag.Commands/Commands/AssemblyTypeToSwaggerCommandBase.cs
+++ b/src/NSwag.Commands/Commands/AssemblyTypeToSwaggerCommandBase.cs
@@ -81,6 +81,13 @@ namespace NSwag.Commands
             set { Settings.GenerateKnownTypes = value; }
         }
 
+        [Argument(Name = "NullHandling", IsRequired = false, Description = "The default null value handling ('JsonSchema' or 'Swagger'), default: JsonSchema.")]
+        public NullHandling NullHandling
+        {
+            get { return Settings.NullHandling; }
+            set { Settings.NullHandling = value; }
+        }
+
         public override async Task<object> RunAsync(CommandLineProcessor processor, IConsoleHost host)
         {
             var document = await RunAsync();


### PR DESCRIPTION
The schema generated by the types2swagger command currently cannot be used with tools like swagger-codegen because the null-value handling is based on "oneOf" rather than on "requires" patterns. This could be configured via the NJsonSchema's NullHandling configuration setting.

This pull request exposes the NullHandling setting via the parameters of the AssymblyTypeToSwagger command, so it can be configured as needed.