### PR TITLE
"title" field in camel case name is not ignored

### DIFF
--- a/src/NSwag.Core/SwaggerDocument.cs
+++ b/src/NSwag.Core/SwaggerDocument.cs
@@ -147,6 +147,7 @@ namespace NSwag
             var jsonResolver = new IgnorableSerializerContractResolver();
             // Ignore properties which are not allowed in Swagger
             jsonResolver.Ignore(typeof(JsonSchema4), "Title");
+            jsonResolver.Ignore(typeof(JsonSchema4), "title");
 
             var serializerSettings = new JsonSerializerSettings
             {


### PR DESCRIPTION
I could still recreate this issue in 8.2 and sources of master with camel case property names due to case sensitive hash lookup. Other alternative fix would be to use a collection that allowed case insensitive lookup, which is much higher impact change.