### PR TITLE
added "*" support for ClassNames

### DIFF
--- a/src/NSwag.AssemblyLoaderCore/SwaggerGenerators/AssemblyTypeToSwaggerGenerator.cs
+++ b/src/NSwag.AssemblyLoaderCore/SwaggerGenerators/AssemblyTypeToSwaggerGenerator.cs
@@ -51,6 +51,13 @@ namespace NSwag.CodeGeneration.SwaggerGenerators
                 return new string[] { };
         }
 
+        /// <summary>Generates the Swagger definition for all classes without operations (used for class generation).</summary>
+        /// <returns>The Swagger definition.</returns>
+        public override Task<SwaggerDocument> GenerateAsync()
+        {
+            return GenerateAsync(GetClasses());
+        }
+
         /// <summary>Generates the Swagger definition for the given classes without operations (used for class generation).</summary>
         /// <param name="classNames">The class names.</param>
         /// <returns>The Swagger definition.</returns>

--- a/src/NSwag.CodeGeneration/SwaggerGenerators/AssemblyTypeToSwaggerGeneratorBase.cs
+++ b/src/NSwag.CodeGeneration/SwaggerGenerators/AssemblyTypeToSwaggerGeneratorBase.cs
@@ -23,7 +23,11 @@ namespace NSwag.CodeGeneration.SwaggerGenerators
         /// <summary>Gets or sets the settings.</summary>
         public AssemblyTypeToSwaggerGeneratorSettings Settings { get; protected set; }
 
-        /// <summary>Generates the specified class names.</summary>
+        /// <summary>Generates the swagger document for all public/exported classes.</summary>
+        /// <returns>The Swagger document.</returns>
+        public abstract Task<SwaggerDocument> GenerateAsync();
+
+        /// <summary>Generates the swagger document for the specified classes.</summary>
         /// <param name="classNames">The class names.</param>
         /// <returns>The Swagger document.</returns>
         public abstract Task<SwaggerDocument> GenerateAsync(string[] classNames);

--- a/src/NSwag.Commands/Commands/AssemblyTypeToSwaggerCommandBase.cs
+++ b/src/NSwag.Commands/Commands/AssemblyTypeToSwaggerCommandBase.cs
@@ -94,6 +94,13 @@ namespace NSwag.Commands
             return await Task.Run(async () =>
             {
                 var generator = CreateGenerator();
+
+                // if the caller specified Classes as "*", treat it as a wildcard
+                if (ClassNames?.Length == 1 && ClassNames[0] == "*")
+                {
+                    return await generator.GenerateAsync().ConfigureAwait(false);
+                }
+
                 return await generator.GenerateAsync(ClassNames).ConfigureAwait(false);
             });
         }


### PR DESCRIPTION
I wanted to run swagger the following way:

```xml
  <Target Name="AfterBuild">
    <Exec Command="$(NSwagExe) types2swagger /assembly:$(OutDir)/MyDto.dll /output:swagger.json" />
  </Target>
```

And generate the Swagger model/DTO documentation for *all* my DTOs. 
At the moment, it is mandatory to manually specify the included types which adds a lot of overhead to the maintenance process (not to mention room for error when namespaces change).

This PR adds a simple `*` support, which can indicate I want all the publicly exported classes from the assembly to be included.

```xml
  <Target Name="AfterBuild">
    <Exec Command="$(NSwagExe) types2swagger /assembly:$(OutDir)/MyDto.dll /output:swagger.json /classnames:*" />
  </Target>
```

Hope this is useful.