### PR TITLE
export keyword for module and namespace blocks in FileTemplate.tt for TypeScript.

### DIFF
--- a/src/NSwag.CodeGeneration/CodeGenerators/TypeScript/Templates/FileTemplate.tt
+++ b/src/NSwag.CodeGeneration/CodeGenerators/TypeScript/Templates/FileTemplate.tt
@@ -24,10 +24,10 @@ import { HttpClient } from 'aurelia-fetch-client';
 <#}#>
 
 <#if(Model.HasModuleName){#>
-module <#=Model.ModuleName#> {
+export module <#=Model.ModuleName#> {
 <#}
   if(Model.HasNamespace){#>
-namespace <#=Model.Namespace#> {
+export namespace <#=Model.Namespace#> {
 <#}#>
 <#if(Model.IsAngular2){#>
 export const API_BASE_URL = new OpaqueToken('API_BASE_URL');


### PR DESCRIPTION
Hi guys!
First of all i want to thank you for your work on NSwag. I’ve looked at several WebApi to TypeScript generators and NSwag is the best. It's easy to use, and very flexible. Moreover it works with ASP.NET Core controllers - exactly what we need in our new project.
I would like to suggest you a little fix in FileTemplate.tt to  generate modules and namespace with export keyword. It is impossible now to import and use generated entities if module and/or namespace were specified in generator settings.