### PR TITLE
Update OperationParameterProcessor.cs

### DIFF
--- a/src/NSwag.CodeGeneration/SwaggerGenerators/WebApi/Processors/OperationParameterProcessor.cs
+++ b/src/NSwag.CodeGeneration/SwaggerGenerators/WebApi/Processors/OperationParameterProcessor.cs
@@ -66,7 +66,13 @@ namespace NSwag.CodeGeneration.SwaggerGenerators.WebApi.Processors
                         dynamic fromUriAttribute = parameterAttributes.SingleOrDefault(a => a.GetType().Name == "FromUriAttribute" || a.GetType().Name == "FromQueryAttribute");
                         dynamic fromRouteAttribute = parameterAttributes.SingleOrDefault(a => a.GetType().FullName == "Microsoft.AspNetCore.Mvc.FromRouteAttribute");
                         dynamic fromHeaderAttribute = parameterAttributes.SingleOrDefault(a => a.GetType().FullName == "Microsoft.AspNetCore.Mvc.FromHeaderAttribute");
-
+                        
+                        var hasCustomAttribute = parameterAttributes.Any(a => !a.GetType().FullName.Contains("System") && !a.GetType().FullName.Contains("Microsoft"));
+                        if (hasCustomAttribute)
+                        {
+                            continue;
+                        }
+                        
                         if (fromRouteAttribute != null)
                         {
                             parameterName = !string.IsNullOrEmpty(fromRouteAttribute.Name) ? fromRouteAttribute.Name : parameter.Name;


### PR DESCRIPTION
ignores parameters that have custom attributes

the reason for this can be seen in issue #546 