### PR TITLE
Fetch typescript fixes

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClientTemplate.tt
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClientTemplate.tt
@@ -82,12 +82,12 @@ export class <#=Model.Class#> <#if(Model.HasClientBaseClass){#>extends <#=Model.
 <#if(Model.UseTransformOptionsMethod){#>
         return this.transformOptions(options_).then(transformedOptions_ => {
             return this.http.fetch(url_, transformedOptions_);
-        }).then((response) => {
+        }).then((response: Response) => {
 <#}else{#>
-        return this.http.fetch(url_, options_).then((response) => {
+        return this.http.fetch(url_, options_).then((response: Response) => {
 <#}#>
 <#if(Model.UseTransformResultMethod){#>
-            return this.transformResult(url_, response, (response) => this.process<#=operation.OperationNameUpper#>(response));
+            return this.transformResult(url_, response, (response: Response) => this.process<#=operation.OperationNameUpper#>(response));
 <#}else{#>
             return this.process<#=operation.OperationNameUpper#>(response);
 <#}#>

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/ProcessResponseTemplate.tt
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/ProcessResponseTemplate.tt
@@ -3,7 +3,7 @@
 <#foreach(var response in Model.Responses){#>
 if (status === <#=response.StatusCode#>) {
 <#  if(response.HasType){#>
-    let result<#=response.StatusCode#>: <#=response.Type#> = null;
+    let result<#=response.StatusCode#>: <#=response.Type#> | null = null;
 <#      if(response.IsDate){#>
     result<#=response.StatusCode#> = new Date(responseText);
 <#      }else{
@@ -27,7 +27,7 @@ if (status === <#=response.StatusCode#>) {
 } else <#}
 if(Model.HasDefaultResponse){#>{
 <#  if(Model.DefaultResponse.HasType){#>
-    let result: <#=Model.DefaultResponse.Type#> = null;
+    let result: <#=Model.DefaultResponse.Type#> | null = null;
 <#      if(Model.DefaultResponse.IsDate){#>
     result = new Date(responseText);
 <#      }else{


### PR DESCRIPTION
Fixes to prevent client errors in Typescript with implicit any disabled.
Also prevents errors for assigning the result200 variable to null