### PR TITLE
API client, use object not arg variables

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClientTemplate.tt
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClientTemplate.tt
@@ -82,12 +82,12 @@ export class <#=Model.Class#> <#if(Model.HasClientBaseClass){#>extends <#=Model.
 <#if(Model.UseTransformOptionsMethod){#>
         return this.transformOptions(options_).then(transformedOptions_ => {
             return this.http.fetch(url_, transformedOptions_);
-        }).then((response) => {
+        }).then((response: Response) => {
 <#}else{#>
-        return this.http.fetch(url_, options_).then((response) => {
+        return this.http.fetch(url_, options_).then((response: Response) => {
 <#}#>
 <#if(Model.UseTransformResultMethod){#>
-            return this.transformResult(url_, response, (response) => this.process<#=operation.OperationNameUpper#>(response));
+            return this.transformResult(url_, response, (response: Response) => this.process<#=operation.OperationNameUpper#>(response));
 <#}else{#>
             return this.process<#=operation.OperationNameUpper#>(response);
 <#}#>

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClientTemplate.tt
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClientTemplate.tt
@@ -55,7 +55,7 @@ export class <#=Model.Class#> <#if(Model.HasClientBaseClass){#>extends <#=Model.
 <#}#><#}#><#if(operation.HasResultDescription){#>     * @return <#=operation.ResultDescription#>
 <#}#><#if(operation.IsDeprecated){#>     * @deprecated
 <#}#>     */
-<#}#>    <#=operation.OperationNameLower#>(<#foreach(var parameter in operation.Parameters){#><#=parameter.VariableName#>: <#=parameter.Type#><#if(!parameter.IsLast){#>, <#}#><#}#>): Promise<<#=operation.ResultType#>> {
+<#}#>    <#=operation.OperationNameLower#>(q: {<#foreach(var parameter in operation.Parameters){#><#=parameter.VariableName#>: <#=parameter.Type#><#if(!parameter.IsLast){#>, <#}#><#}#> }): Promise<<#=operation.ResultType#>> {
         <#=TypeScriptTemplatePartGenerator.RenderRequestUrlCode(operation, 2)#>
 
 <#if(!operation.IsGetOrHead){#>

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/ProcessResponseTemplate.tt
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/ProcessResponseTemplate.tt
@@ -3,7 +3,7 @@
 <#foreach(var response in Model.Responses){#>
 if (status === <#=response.StatusCode#>) {
 <#  if(response.HasType){#>
-    let result<#=response.StatusCode#>: <#=response.Type#> = null;
+    let result<#=response.StatusCode#>: <#=response.Type#> | null = null;
 <#      if(response.IsDate){#>
     result<#=response.StatusCode#> = new Date(responseText);
 <#      }else{
@@ -27,7 +27,7 @@ if (status === <#=response.StatusCode#>) {
 } else <#}
 if(Model.HasDefaultResponse){#>{
 <#  if(Model.DefaultResponse.HasType){#>
-    let result: <#=Model.DefaultResponse.Type#> = null;
+    let result: <#=Model.DefaultResponse.Type#> | null = null;
 <#      if(Model.DefaultResponse.IsDate){#>
     result = new Date(responseText);
 <#      }else{

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/RequestBodyTemplate.tt
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/RequestBodyTemplate.tt
@@ -3,20 +3,20 @@
 const content_ = new FormData();
 <#foreach(var parameter in Model.FormParameters){#>
 <#  if(parameter.IsNullable){#>
-if (<#=parameter.VariableName#> !== null)
+if (q.<#=parameter.VariableName#> !== null)
 <#  }else{#>
-if (<#=parameter.VariableName#> === null)
-    throw new Error("The parameter '<#=parameter.VariableName#>' cannot be null.");
+if (q.<#=parameter.VariableName#> === null)
+    throw new Error("The parameter 'q.<#=parameter.VariableName#>' cannot be null.");
 else
 <#  }#>
 <#  if(parameter.IsFile){
         if(parameter.IsArray){#>
-    <#=parameter.VariableName#>.forEach(item_ => content_.append("<#=parameter.Name#>", item_.data, item_.fileName ? item_.fileName : "<#=parameter.Name#>") );
+    q.<#=parameter.VariableName#>.forEach(item_ => content_.append("<#=parameter.Name#>", item_.data, item_.fileName ? item_.fileName : "<#=parameter.Name#>") );
 <#      }else{#>
-    content_.append("<#=parameter.Name#>", <#=parameter.VariableName#>.data, <#=parameter.VariableName#>.fileName ? <#=parameter.VariableName#>.fileName : "<#=parameter.Name#>");
+    content_.append("<#=parameter.Name#>", q.<#=parameter.VariableName#>.data, q.<#=parameter.VariableName#>.fileName ? q.<#=parameter.VariableName#>.fileName : "<#=parameter.Name#>");
 <#      }
     }else{#>
-    content_.append("<#=parameter.Name#>", <#=parameter.VariableName#>.toString());
+    content_.append("<#=parameter.Name#>", q.<#=parameter.VariableName#>.toString());
 <#  }#>
 <#}#>
 <#  }else{#>

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/RequestUrlTemplate.tt
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/RequestUrlTemplate.tt
@@ -2,50 +2,50 @@
 <#@ import namespace="System.Linq" #>
 let url_ = this.baseUrl + "/<#=Model.Path#><#if(Model.QueryParameters.Any()){#>?<#}#>";
 <#foreach(var parameter in Model.PathParameters){#>
-if (<#=parameter.VariableName#> === undefined || <#=parameter.VariableName#> === null)
-    throw new Error("The parameter '<#=parameter.VariableName#>' must be defined.");
+if (q.<#=parameter.VariableName#> === undefined || q.<#=parameter.VariableName#> === null)
+    throw new Error("The parameter 'q.<#=parameter.VariableName#>' must be defined.");
 <#if(parameter.IsDateArray){#>
-url_ = url_.replace("{<#=parameter.Name#>}", encodeURIComponent(<#=parameter.VariableName#>.map(s_ => s_.toJSON()).join())); 
+url_ = url_.replace("{<#=parameter.Name#>}", encodeURIComponent(q.<#=parameter.VariableName#>.map(s_ => s_.toJSON()).join())); 
 <#  }else if(parameter.IsDate){#>
-url_ = url_.replace("{<#=parameter.Name#>}", encodeURIComponent("" + <#=parameter.VariableName#>.toJSON())); 
+url_ = url_.replace("{<#=parameter.Name#>}", encodeURIComponent("" + q.<#=parameter.VariableName#>.toJSON())); 
 <#  }else if(parameter.IsArray){#>
-url_ = url_.replace("{<#=parameter.Name#>}", encodeURIComponent(<#=parameter.VariableName#>.join())); 
+url_ = url_.replace("{<#=parameter.Name#>}", encodeURIComponent(q.<#=parameter.VariableName#>.join())); 
 <#  }else{#>
-url_ = url_.replace("{<#=parameter.Name#>}", encodeURIComponent("" + <#=parameter.VariableName#>)); 
+url_ = url_.replace("{<#=parameter.Name#>}", encodeURIComponent("" + q.<#=parameter.VariableName#>)); 
 <#  }
   }
   foreach(var parameter in Model.QueryParameters){
     if (parameter.IsRequired) { 
         if(parameter.IsNullable){#>
-if (<#=parameter.VariableName#> === undefined)
-    throw new Error("The parameter '<#=parameter.VariableName#>' must be defined.");
+if (q.<#=parameter.VariableName#> === undefined)
+    throw new Error("The parameter 'q.<#=parameter.VariableName#>' must be defined.");
 else
 <#      }else{#>
-if (<#=parameter.VariableName#> === undefined || <#=parameter.VariableName#> === null)
-    throw new Error("The parameter '<#=parameter.VariableName#>' must be defined and cannot be null.");
+if (q.<#=parameter.VariableName#> === undefined || q.<#=parameter.VariableName#> === null)
+    throw new Error("The parameter 'q.<#=parameter.VariableName#>' must be defined and cannot be null.");
 else
 <#      }
     }else{
         if(parameter.IsNullable){#>
-if (<#=parameter.VariableName#> !== undefined)
+if (<q.#=parameter.VariableName#> !== undefined)
 <#      }else{#>
-if (<#=parameter.VariableName#> === null)
-    throw new Error("The parameter '<#=parameter.VariableName#>' cannot be null.");
-else if (<#=parameter.VariableName#> !== undefined)
+if (q.<#=parameter.VariableName#> === null)
+    throw new Error("The parameter 'q.<#=parameter.VariableName#>' cannot be null.");
+else if (q.<#=parameter.VariableName#> !== undefined)
 <#      }
     }
     if(parameter.IsDateArray){#>
-    <#=parameter.VariableName#>.forEach(item => { url_ += "<#=parameter.Name#>=" + encodeURIComponent("" + item.toJSON()) + "&"; });
+    q.<#=parameter.VariableName#>.forEach(item => { url_ += "<#=parameter.Name#>=" + encodeURIComponent("" + item.toJSON()) + "&"; });
 <#  }else if(parameter.IsObjectArray){#>
-    <#=parameter.VariableName#>.forEach((item, index) => { 
+    q.<#=parameter.VariableName#>.forEach((item, index) => { 
         for (let attr in item)
             url_ += "<#=parameter.Name#>[" + index + "]." + attr + "=" + encodeURIComponent("" + item[attr]) + "&";
     });
 <#  }else if(parameter.IsDate){#>
-    url_ += "<#=parameter.Name#>=" + encodeURIComponent("" + <#=parameter.VariableName#>.toJSON()) + "&"; 
+    url_ += "<#=parameter.Name#>=" + encodeURIComponent("" + q.<#=parameter.VariableName#>.toJSON()) + "&"; 
 <#  }else if(parameter.IsArray){#>
-    <#=parameter.VariableName#>.forEach(item => { url_ += "<#=parameter.Name#>=" + encodeURIComponent("" + item) + "&"; });
+    q.<#=parameter.VariableName#>.forEach(item => { url_ += "<#=parameter.Name#>=" + encodeURIComponent("" + item) + "&"; });
 <#  }else{#>
-    url_ += "<#=parameter.Name#>=" + encodeURIComponent("" + <#=parameter.VariableName#>) + "&"; 
+    url_ += "<#=parameter.Name#>=" + encodeURIComponent("" + q.<#=parameter.VariableName#>) + "&"; 
 <#  }
 }#>


### PR DESCRIPTION
Not sure if there is a neater way to do this, and may want to make this optional, but this opens up the capabilities of spread operators and the like to any complex api client calls.
so if I start with an api that can take a number of options on a GET call, I would currently get each parameter as an argument variable.
This moves it to always generate with a single argument object
So we move from `get(id: int, from: Date, to: Date)`
to `get(q: {id: int, from: Date, to: Date})`
which opens up all the goodness of object destructuring, spread operators, and other es6 features

one alternate approach would be to only do this based on the original API signature in the web api controller.
so:
```c#
[HttpGet]
[Route("{rateId:int}")]
[ResponseType(typeof(Shared.DTOs.Thing))]
public IHttpActionResult GetById(long id) {

}

[HttpGet]
[Route("Get")]
[ResponseType(typeof(Shared.DTOs.Thing))]
public IHttpActionResult Get([FromUri]SingleQueryModel lookupObj) {
}        
```
would generate
```javascript
getById(id: number): Promise<Thing>;
get(lookupObj: SingleQueryModel): Promise<Thing>;
// rather than the current
get(id: number, otherId: number, workDate: moment.Moment, dimensionIds: string, ...etc): Promise<Thing>;
```
which I think may be a better approach, but coudlnt immediately see how to make that happen?