### PR TITLE
Use DynamicApis.HttpGetAsync to resolve encoding issues

### DIFF
--- a/src/NSwagStudio/ViewModels/SwaggerGenerators/SwaggerInputViewModel.cs
+++ b/src/NSwagStudio/ViewModels/SwaggerGenerators/SwaggerInputViewModel.cs
@@ -4,6 +4,7 @@ using System.Windows.Input;
 using MyToolkit.Command;
 using Newtonsoft.Json;
 using NSwag.Commands;
+using NJsonSchema.Infrastructure;
 
 namespace NSwagStudio.ViewModels.SwaggerGenerators
 {
@@ -20,14 +21,8 @@ namespace NSwagStudio.ViewModels.SwaggerGenerators
 
         public async Task LoadSwaggerUrlAsync(string url)
         {
-            var json = string.Empty;
-            await RunTaskAsync(() =>
-            {
-                using (var client = new WebClient())
-                    json = JsonConvert.SerializeObject(JsonConvert.DeserializeObject(client.DownloadString(url)), Formatting.Indented);
-            });
-
-            Command.Swagger = json;
+            var json = await DynamicApis.HttpGetAsync(url).ConfigureAwait(false);
+            Command.Swagger = JsonConvert.SerializeObject(JsonConvert.DeserializeObject(json), Formatting.Indented);
         }
 
         public async Task<string> GenerateSwaggerAsync()


### PR DESCRIPTION
Small change to support different encodings when using the NSwagStudio load from url.


Another question:
I'm having issues [syncing my fork](https://help.github.com/articles/syncing-a-fork/#platform-windows) :( , this is due to files I haven't touched that are listed as modified by `git status` (something with changed line endings).

Is it possible I'm using a different git autocrlf setting?
`git config core.autocrlf`