### PR TITLE
Fix external reference to jsonschema ($ref with path to another file)

### DIFF
--- a/src/NSwag.Core/SwaggerDocument.cs
+++ b/src/NSwag.Core/SwaggerDocument.cs
@@ -177,7 +177,9 @@ namespace NSwag
             });
             document.DocumentPath = documentPath;
 
-            var schemaResolver = new JsonSchemaResolver(documentPath, new JsonSchemaGeneratorSettings());
+            var jsonSchema = JsonSchema4.FromData(data);
+
+            var schemaResolver = new JsonSchemaResolver(jsonSchema, new JsonSchemaGeneratorSettings());
             var referenceResolver = new JsonReferenceResolver(schemaResolver); 
             await JsonSchemaReferenceUtilities.UpdateSchemaReferencesAsync(document, referenceResolver).ConfigureAwait(false);
             return document;


### PR DESCRIPTION
Hi,

Using $ref to target jsonschema in separated json file throw a cast exception.

JsonSchemaResolver should be instancied with an instance of JsonSchema.
