### PR TITLE
TypeScript response code handling bug

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpOperationModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpOperationModel.cs
@@ -152,7 +152,7 @@ namespace NSwag.CodeGeneration.CSharp.Models
         /// <returns></returns>
         protected override CSharpResponseModel CreateResponseModel(string statusCode, SwaggerResponse response, JsonSchema4 exceptionSchema, IClientGenerator generator, ClientGeneratorBaseSettings settings)
         {
-            return new CSharpResponseModel(statusCode, response, response == GetSuccessResponse(), exceptionSchema, generator, settings.CodeGeneratorSettings);
+            return new CSharpResponseModel(statusCode, response, HttpUtilities.IsSuccessStatusCode(statusCode), exceptionSchema, generator, settings.CodeGeneratorSettings);
         }
     }
 }

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/NSwag.CodeGeneration.TypeScript.Tests.csproj
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/NSwag.CodeGeneration.TypeScript.Tests.csproj
@@ -60,10 +60,15 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ArrayParameterTests.cs" />
+    <Compile Include="StatusCodeHandlingTests.cs" />
     <Compile Include="OperationParameterTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\NSwag.Annotations\NSwag.Annotations.csproj">
+      <Project>{ca084154-e758-4a44-938d-7806af2dd886}</Project>
+      <Name>NSwag.Annotations</Name>
+    </ProjectReference>
     <ProjectReference Include="..\NSwag.CodeGeneration.TypeScript\NSwag.CodeGeneration.TypeScript.csproj">
       <Project>{9293CFCD-6C7B-43E0-9FBD-88753EBF64CC}</Project>
       <Name>NSwag.CodeGeneration.TypeScript</Name>

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/StatusCodeHandlingTests.cs
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/StatusCodeHandlingTests.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Web.Http;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NJsonSchema;
+using NSwag.Annotations;
+using NSwag.SwaggerGeneration.WebApi;
+
+namespace NSwag.CodeGeneration.TypeScript.Tests
+{
+    [TestClass]
+    public class StatusCodeHandlingTests
+    {
+        public class FooController : ApiController
+        {
+            [Route("foos/")]
+            [SwaggerResponse(200, null)]
+            [SwaggerResponse(201, null)]
+            [SwaggerResponse(301, null)]
+            [SwaggerResponse(400, null)]
+            [SwaggerResponse(500, null)]
+            public Foo[] GetFoos([FromUri] Bar[] bars)
+            {
+                return new Foo[0];
+            }
+        }
+
+        public enum Bar
+        {
+            Baz,
+            Foo
+        }
+
+        public class Foo
+        {
+            public Bar Bar { get; set; }
+
+            public Bar Bar2 { get; set; }
+        }
+
+        [TestMethod]
+        public async Task When_multiple_success_and_error_response_codes_are_declared_typescript_exceptions_are_only_thrown_for_error_codes()
+        {
+            //// Arrange
+            var settings = new WebApiToSwaggerGeneratorSettings
+            {
+                DefaultUrlTemplate = "api/{controller}/{action}/{id}",
+                DefaultEnumHandling = EnumHandling.String,
+                DefaultPropertyNameHandling = PropertyNameHandling.Default,
+                NullHandling = NullHandling.Swagger,
+            };
+            var generator = new WebApiToSwaggerGenerator(settings);
+
+            //// Act
+            var document = await generator.GenerateForControllerAsync<FooController>();
+
+            var gen = new SwaggerToTypeScriptClientGenerator(document, new SwaggerToTypeScriptClientGeneratorSettings
+            {
+                Template = TypeScriptTemplate.Angular2
+            });
+
+            var code = gen.GenerateFile();
+
+            var codeOnASingleLine = string.Join("",
+                code.Split(new[] { Environment.NewLine, "  " }, StringSplitOptions.RemoveEmptyEntries).Select(n => n.Trim()).Where(n => n.Length > 0));
+
+            Assert.IsFalse(codeOnASingleLine.Contains("} else if (status === 201) {this.throwException(\"A server error occurred.\", status, responseText);"));
+            Assert.IsTrue(codeOnASingleLine.Contains("} else if (status === 201) {return null;"));
+        }
+    }
+}

--- a/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptOperationModel.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptOperationModel.cs
@@ -94,7 +94,7 @@ namespace NSwag.CodeGeneration.TypeScript.Models
         /// <returns></returns>
         protected override TypeScriptResponseModel CreateResponseModel(string statusCode, SwaggerResponse response, JsonSchema4 exceptionSchema, IClientGenerator generator, ClientGeneratorBaseSettings settings)
         {
-            return new TypeScriptResponseModel(statusCode, response, response == GetSuccessResponse(), exceptionSchema, generator, (TypeScriptGeneratorSettings) settings.CodeGeneratorSettings);
+            return new TypeScriptResponseModel(statusCode, response, HttpUtilities.IsSuccessStatusCode(statusCode), exceptionSchema, generator, (TypeScriptGeneratorSettings) settings.CodeGeneratorSettings);
         }
     }
 }


### PR DESCRIPTION
Generating typescript client code for the controller below, resulted in exception throw statements for status codes that are not errors.

    public class FooController : ApiController
        {
            [Route("foos/")]
            [SwaggerResponse(200, null)]
            [SwaggerResponse(201, null)]
            [SwaggerResponse(400, null)]
            [SwaggerResponse(500, null)]
            public Foo[] GetFoos([FromUri] Bar[] bars)
            {
                return new Foo[0];
            }
        }

Before:

    protected processGetFoos(response: Response): void {
        const responseText = response.text();
        const status = response.status; 

        if (status === 200) {
            return null;
        } else if (status === 201) {
            this.throwException("A server error occurred.", status, responseText);
        } else if (status === 400) {
            this.throwException("A server error occurred.", status, responseText);
        } else if (status === 500) {
            this.throwException("A server error occurred.", status, responseText);
        } else if (status !== 200 && status !== 204) {
            this.throwException("An unexpected server error occurred.", status, responseText);
        }
        return null;
    }

Clearly, a HTTP 201 is not supposed to be handled as an error.

After:

    protected processGetFoos(response: Response): void {
        const responseText = response.text();
        const status = response.status; 

        if (status === 200) {
            return null;
        } else if (status === 201) {
            return null;
        } else if (status === 400) {
            this.throwException("A server error occurred.", status, responseText);
        } else if (status === 500) {
            this.throwException("A server error occurred.", status, responseText);
        } else if (status !== 200 && status !== 204) {
            this.throwException("An unexpected server error occurred.", status, responseText);
        }
        return null;
    }
