### PR TITLE
Fix SwaggerDocument.BasePath when MiddlewareBasePath is null

### DIFF
--- a/src/NSwag.AspNet.Owin/SwaggerMiddleware.cs
+++ b/src/NSwag.AspNet.Owin/SwaggerMiddleware.cs
@@ -68,7 +68,7 @@ namespace NSwag.AspNet.Owin
 
                     document.Host = context.Request.Host.Value ?? "";
                     document.Schemes.Add(context.Request.Scheme == "http" ? SwaggerSchema.Http : SwaggerSchema.Https);
-                    document.BasePath = context.Request.PathBase.Value?.Substring(0, context.Request.PathBase.Value.Length - _settings.MiddlewareBasePath?.Length ?? 0) ?? "";
+                    document.BasePath = context.Request.PathBase.Value?.Substring(0, context.Request.PathBase.Value.Length - (_settings.MiddlewareBasePath?.Length ?? 0)) ?? "";
 
                     _settings.PostProcess?.Invoke(document);
                     _swaggerJson = document.ToJson();

--- a/src/NSwag.AspNetCore/SwaggerMiddleware.cs
+++ b/src/NSwag.AspNetCore/SwaggerMiddleware.cs
@@ -72,7 +72,7 @@ namespace NSwag.AspNetCore
 
                         document.Host = context.Request.Host.Value ?? "";
                         document.Schemes.Add(context.Request.Scheme == "http" ? SwaggerSchema.Http : SwaggerSchema.Https);
-                        document.BasePath = context.Request.PathBase.Value?.Substring(0, context.Request.PathBase.Value.Length - _settings.MiddlewareBasePath?.Length ?? 0) ?? "";
+                        document.BasePath = context.Request.PathBase.Value?.Substring(0, context.Request.PathBase.Value.Length - (_settings.MiddlewareBasePath?.Length ?? 0)) ?? "";
 
                         _settings.PostProcess?.Invoke(document);
                         _swaggerJson = document.ToJson();


### PR DESCRIPTION
This code attempts to set BasePath based on MiddlewareBasePath's length, defaulting to 0 when MiddlewareBasePath is null. The code fails miserably.

`10 - (int?)null ?? 0` is interpreted as `(10 - (int?)null) ?? 0` and evaluates to 0.