### PR TITLE
Fix ignoring parameters

### DIFF
--- a/src/NSwag.SwaggerGeneration.WebApi/Processors/OperationParameterProcessor.cs
+++ b/src/NSwag.SwaggerGeneration.WebApi/Processors/OperationParameterProcessor.cs
@@ -42,7 +42,7 @@ namespace NSwag.SwaggerGeneration.WebApi.Processors
             var httpPath = context.OperationDescription.Path;
             var parameters = context.MethodInfo.GetParameters().ToList();
             foreach (var parameter in parameters.Where(p => p.ParameterType != typeof(CancellationToken) &&
-                                                            p.GetCustomAttributes().All(a => a.GetType().InheritsFrom("SwaggerIgnoreAttribute", TypeNameStyle.Name) == false) &&
+                                                            p.GetCustomAttributes().All(a => a.GetType().Name != "SwaggerIgnoreAttribute") &&
                                                             p.GetCustomAttributes().All(a => a.GetType().Name != "FromServicesAttribute") &&
                                                             p.GetCustomAttributes().All(a => a.GetType().Name != "BindNeverAttribute")))
             {


### PR DESCRIPTION
In all other places the SwaggerIgnoreAttribute is matched exactly by name; but for parameters a type that inherits from SwaggerIgnoreAttribute is expected. This makes hiding parameters tedious as it requires creating a new attribute type and produces inconsistency in the way that annotations are handled. This commit makes annotation handling consistent and allows [SwaggerIgnore] on parameters.