### PR TITLE
Bugfixes for when Model.WrapResponses is enabled

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/ControllerTemplate.tt
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/ControllerTemplate.tt
@@ -1,6 +1,10 @@
 ﻿<#@ template visibility="internal" #>
 <#@ import namespace="NJsonSchema" #>
 
+<# if (Model.WrapResponses){#>
+using System.Net.Http;
+<# }#>
+
 [System.CodeDom.Compiler.GeneratedCode("NSwag", "<#=SwaggerDocument.ToolchainVersion#>")]
 public interface I<#=Model.Class#>Controller
 {
@@ -35,16 +39,16 @@ public partial class <#=Model.Class#>Controller : <#if(Model.HasBaseClass){#><#=
 <#  }}if(operation.HasResultDescription){#>    /// <returns><#=ConversionUtilities.ConvertCSharpDocBreaks(operation.ResultDescription, 1)#></returns>
 <#  }if(operation.IsDeprecated){#>    [System.Obsolete]
 <#  }#>    [System.Web.Http.Http<#=operation.HttpMethodUpper#>, System.Web.Http.Route("<#=operation.Path#>")]
-    public <#if(Model.WrapResponses){#>async System.Threading.Tasks.Task<HttpResponseMessage><#}else{#><#=operation.ResultType#><#}#> <#=operation.ActualOperationName#>(<#foreach(var parameter in operation.Parameters){#><#=parameter.Type#> <#=parameter.VariableName#><#if(Model.GenerateOptionalParameters && parameter.IsOptional){#> = null<#}#><#if(!parameter.IsLast){#>, <#}}#>)
+    public <#if(Model.WrapResponses){#>async System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage><#}else{#><#=operation.ResultType#><#}#> <#=operation.ActualOperationName#>(<#foreach(var parameter in operation.Parameters){#><#=parameter.Type#> <#=parameter.VariableName#><#if(Model.GenerateOptionalParameters && parameter.IsOptional){#> = null<#}#><#if(!parameter.IsLast){#>, <#}}#>)
     {    
 <#          if (Model.WrapResponses){#>
         var result = await _implementation.<#=operation.ActualOperationName#>Async(<#foreach(var parameter in operation.Parameters){#><#=parameter.VariableName#><#if(!parameter.IsLast){#>, <#}}#>);
 
-        var status = (HttpStatusCode)Enum.Parse(typeof(HttpStatusCode), result.StatusCode);
+        var status = (System.Net.HttpStatusCode)System.Enum.Parse(typeof(System.Net.HttpStatusCode), result.StatusCode);
         HttpResponseMessage response = Request.CreateResponse(status<#if(operation.UnwrappedResultType != "void"){#>, result.Result<#}#>);
     
         foreach (var header in result.Headers)
-            response.Headers[header.Key] = header.Value;
+            response.Headers.Add(header.Key, header.Value);
 
         return response;
 <#          }else{#>


### PR DESCRIPTION
4 fixes:
1) Fully qualified System.Net.HttpStatusCode
2) Fully qualified System.Enum
3) Using System.Net.Http to access extension method in Request.CreateResponse (line 48)
4) Use "Add" function for response headers to resolve compilation issue.