### PR TITLE
Follow class hierarchy when locating RouteAttributes

### DIFF
--- a/src/NSwag.SwaggerGeneration.WebApi.Tests/NSwag.SwaggerGeneration.WebApi.Tests.csproj
+++ b/src/NSwag.SwaggerGeneration.WebApi.Tests/NSwag.SwaggerGeneration.WebApi.Tests.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Attributes\RouteTests.cs" />
     <Compile Include="Attributes\TagsTests.cs" />
     <Compile Include="ControllerClassesTests.cs" />
+    <Compile Include="RouteAttributeTests.cs" />
     <Compile Include="EnumListTests.cs" />
     <Compile Include="FileParameterTests.cs" />
     <Compile Include="FileResponseTests.cs" />

--- a/src/NSwag.SwaggerGeneration.WebApi.Tests/RouteAttributeTests.cs
+++ b/src/NSwag.SwaggerGeneration.WebApi.Tests/RouteAttributeTests.cs
@@ -1,0 +1,50 @@
+﻿using System.Threading.Tasks;
+using System.Web.Http;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace NSwag.SwaggerGeneration.WebApi.Tests
+{
+    [TestClass]
+    public class RouteAttributeTests
+    {
+       [Route("/api/[controller]")]
+       public abstract class BaseTestController : ApiController
+       {
+       }
+
+        public class FooController : BaseTestController
+        {
+            public void Post()
+            {
+            }
+        }
+
+        [Route("/api/other")]
+        public class BarController : BaseTestController
+        {
+            public void Post()
+            {
+            }
+        }
+
+        [TestMethod]
+        public async Task Use_base_class_route_attribute()
+        {
+            var generator = new WebApiToSwaggerGenerator(new WebApiToSwaggerGeneratorSettings());
+            var document = await generator.GenerateForControllerAsync<FooController>();
+            var swaggerSpecification = document.ToJson();
+
+            StringAssert.Contains(swaggerSpecification, "\"/api/Foo\"");
+        }
+
+        [TestMethod]
+        public async Task Route_attribute_overrides_base()
+        {
+            var generator = new WebApiToSwaggerGenerator(new WebApiToSwaggerGeneratorSettings());
+            var document = await generator.GenerateForControllerAsync<BarController>();
+            var swaggerSpecification = document.ToJson();
+
+            StringAssert.Contains(swaggerSpecification, "\"/api/other\"");
+        }
+    }
+}


### PR DESCRIPTION
 * Fix InvalidOperationException (Sequence contains more than one
   element) when RouteAttribute is used at different inheritance
   levels.
 * Changed attribute finding code to walk the inheritance hierarchy
   and only look for attributes at each level, stopping once
   an attribute is found.
 * Added unit tests to demonstrate the behavior.