### PR TITLE
Fix exception when using custom route attributes

### DIFF
--- a/src/NSwag.SwaggerGeneration.WebApi/Infrastructure/RouteAttributeFacade.cs
+++ b/src/NSwag.SwaggerGeneration.WebApi/Infrastructure/RouteAttributeFacade.cs
@@ -22,6 +22,12 @@ namespace NSwag.SwaggerGeneration.WebApi.Infrastructure
     {
         private readonly PropertyInfo _template;
 
+        private RouteAttributeFacade(Attribute attr, PropertyInfo template)
+        {
+            Attribute = attr;
+            _template = template;
+        }
+
         public RouteAttributeFacade(Attribute attr)
         {
             var type = attr.GetType();
@@ -40,12 +46,15 @@ namespace NSwag.SwaggerGeneration.WebApi.Infrastructure
         public static RouteAttributeFacade TryMake(Attribute a)
         {
             var type = a.GetType();
+            var typeInfo = type.GetTypeInfo();
 
             if (type.Name == "RouteAttribute" ||
-                type.GetTypeInfo().ImplementedInterfaces.Any(i => i.Name == "IHttpRouteInfoProvider") ||
-                type.GetTypeInfo().ImplementedInterfaces.Any(i => i.Name == "IRouteTemplateProvider")) // .NET Core
+                typeInfo.ImplementedInterfaces.Any(i => i.Name == "IHttpRouteInfoProvider") ||
+                typeInfo.ImplementedInterfaces.Any(i => i.Name == "IRouteTemplateProvider")) // .NET Core
             {
-                return new RouteAttributeFacade(a);
+                var template = type.GetRuntimeProperty("Template");
+                if (template != null)
+                    return new RouteAttributeFacade(a, template);
             }
 
             return null;

--- a/src/NSwag.SwaggerGeneration.WebApi/Infrastructure/RouteAttributeFacade.cs
+++ b/src/NSwag.SwaggerGeneration.WebApi/Infrastructure/RouteAttributeFacade.cs
@@ -1,0 +1,54 @@
+//-----------------------------------------------------------------------
+// <copyright file="RouteAttributeFacade.cs" company="NSwag">
+//     Copyright (c) Rico Suter. All rights reserved.
+// </copyright>
+// <license>https://github.com/NSwag/NSwag/blob/master/LICENSE.md</license>
+// <author>Rico Suter, mail@rsuter.com</author>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace NSwag.SwaggerGeneration.WebApi.Infrastructure
+{
+    /// <summary>
+    /// Uses reflection to provide a common interface to the following types:
+    /// * RouteAttribute
+    /// * IHttpRouteInfoProvider
+    /// * IRouteTemplateProvider
+    /// </summary>
+    internal class RouteAttributeFacade
+    {
+        private readonly PropertyInfo _template;
+
+        public RouteAttributeFacade(Attribute attr)
+        {
+            var type = attr.GetType();
+
+            _template = type.GetRuntimeProperty("Template");
+            if (_template == null)
+                throw new ArgumentException($"{type.FullName}  does not implement property 'Template'");
+
+            Attribute = attr;
+        }
+
+        public Attribute Attribute { get; }
+
+        public string Template => (string)_template.GetValue(Attribute);
+
+        public static RouteAttributeFacade TryMake(Attribute a)
+        {
+            var type = a.GetType();
+
+            if (type.Name == "RouteAttribute" ||
+                type.GetTypeInfo().ImplementedInterfaces.Any(i => i.Name == "IHttpRouteInfoProvider") ||
+                type.GetTypeInfo().ImplementedInterfaces.Any(i => i.Name == "IRouteTemplateProvider")) // .NET Core
+            {
+                return new RouteAttributeFacade(a);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/NSwag.SwaggerGeneration.WebApi/Infrastructure/RoutePrefixAttributeFacade.cs
+++ b/src/NSwag.SwaggerGeneration.WebApi/Infrastructure/RoutePrefixAttributeFacade.cs
@@ -1,0 +1,52 @@
+//-----------------------------------------------------------------------
+// <copyright file="RoutePrefixAttributeFacade.cs" company="NSwag">
+//     Copyright (c) Rico Suter. All rights reserved.
+// </copyright>
+// <license>https://github.com/NSwag/NSwag/blob/master/LICENSE.md</license>
+// <author>Rico Suter, mail@rsuter.com</author>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace NSwag.SwaggerGeneration.WebApi.Infrastructure
+{
+    /// <summary>
+    /// Uses reflection to provide a common interface to the following types:
+    /// * RoutePrefixAttribute
+    /// * IRoutePrefix
+    /// </summary>
+    internal class RoutePrefixAttributeFacade
+    {
+        private readonly PropertyInfo _prefix;
+
+        public RoutePrefixAttributeFacade(Attribute attr)
+        {
+            var type = attr.GetType();
+
+            _prefix = type.GetRuntimeProperty("Prefix");
+            if (_prefix == null)
+                throw new ArgumentException($"{type.FullName} does not implement property 'Prefix'");
+
+            Attribute = attr;
+        }
+
+        public Attribute Attribute { get; }
+
+        public string Prefix => (string)_prefix.GetValue(Attribute);
+
+        public static RoutePrefixAttributeFacade TryMake(Attribute a)
+        {
+            var type = a.GetType();
+
+            if (type.Name == "RoutePrefixAttribute" ||
+                type.GetTypeInfo().ImplementedInterfaces.Any(i => i.Name == "IRoutePrefix"))
+            {
+                return new RoutePrefixAttributeFacade(a);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/NSwag.SwaggerGeneration.WebApi/WebApiToSwaggerGenerator.cs
+++ b/src/NSwag.SwaggerGeneration.WebApi/WebApiToSwaggerGenerator.cs
@@ -259,12 +259,12 @@ namespace NSwag.SwaggerGeneration.WebApi
             var routeAttributes = GetRouteAttributes(method.GetCustomAttributes()).ToList();
 
             // .NET Core: RouteAttribute on class level
-            dynamic routeAttributeOnClass = GetRouteAttribute(controllerType);
-            dynamic routePrefixAttribute = GetRoutePrefixAttribute(controllerType);
+            var routeAttributeOnClass = GetRouteAttribute(controllerType);
+            var routePrefixAttribute = GetRoutePrefixAttribute(controllerType);
 
             if (routeAttributes.Any())
             {
-                foreach (dynamic attribute in routeAttributes)
+                foreach (var attribute in routeAttributes)
                 {
                     if (attribute.Template.StartsWith("~/")) // ignore route prefixes
                         httpPaths.Add(attribute.Template.Substring(1));
@@ -326,7 +326,7 @@ namespace NSwag.SwaggerGeneration.WebApi
             yield return path;
         }
 
-        private Attribute GetRouteAttribute(Type type)
+        private RouteAttributeFacade GetRouteAttribute(Type type)
         {
             do
             {
@@ -342,7 +342,7 @@ namespace NSwag.SwaggerGeneration.WebApi
             return null;
         }
 
-        private Attribute GetRoutePrefixAttribute(Type type)
+        private RoutePrefixAttributeFacade GetRoutePrefixAttribute(Type type)
         {
             do
             {
@@ -358,18 +358,14 @@ namespace NSwag.SwaggerGeneration.WebApi
             return null;
         }
 
-        private IEnumerable<Attribute> GetRouteAttributes(IEnumerable<Attribute> attributes)
+        private IEnumerable<RouteAttributeFacade> GetRouteAttributes(IEnumerable<Attribute> attributes)
         {
-            return attributes.Where(a => a.GetType().Name == "RouteAttribute" ||
-                                         a.GetType().GetTypeInfo().ImplementedInterfaces.Any(t => t.Name == "IHttpRouteInfoProvider") ||
-                                         a.GetType().GetTypeInfo().ImplementedInterfaces.Any(t => t.Name == "IRouteTemplateProvider")) // .NET Core;
-                             .Where(a => ObjectExtensions.HasProperty(a, "Template") && ((dynamic)a).Template != null);
+            return attributes.Select(RouteAttributeFacade.TryMake).Where(a => a?.Template != null);
         }
 
-        private IEnumerable<Attribute> GetRoutePrefixAttributes(IEnumerable<Attribute> attributes)
+        private IEnumerable<RoutePrefixAttributeFacade> GetRoutePrefixAttributes(IEnumerable<Attribute> attributes)
         {
-            return attributes.Where(a => a.GetType().Name == "RoutePrefixAttribute" ||
-                                         a.GetType().GetTypeInfo().ImplementedInterfaces.Any(t => t.Name == "IRoutePrefix"));
+            return attributes.Select(RoutePrefixAttributeFacade.TryMake).Where(a => a != null);
         }
 
         private string GetActionName(MethodInfo method)


### PR DESCRIPTION
 * Fix potential `RuntimeBinderException` when using custom internal or private `IHttpRouteInfoProvider` attributes
 * `((dynamic)a).Template` throws when the user defined attribute is internal or private, so replace with normal reflection and use `PropertyInfo.GetValue()`
 * Add test to verify internal user defined route attributes work properly
 * Add test to verify route attrs w/null templates are skipped

I looked at the other dynamic usage in the `NSwag.SwaggerGeneration.WebApi` assembly and I think it is ok.  The other usage is doing a.GetType().Name prior to the dynamic cast, and all the target types are public.

Only GetRouteAttribute and GetRoutePrefixAttribute check to see if the attribute implements an interface before performing a dynamic cast.